### PR TITLE
[WIP] Simplify Docker image versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,8 @@ For local development, you can build images for your native platform:
 # Build Rust containers (wrapper, service, watchdog) without cache
 ./scripts/build-rust-images.sh
 
-# Build main language containers (8 languages + 7 common Ruby versions)
+# Build main language containers (8 languages + 16 supported Ruby versions)
 ./scripts/build-language-images.sh
-
-# Build all Ruby versions (110+ versions, takes hours)
-./scripts/build-language-images.sh --all-ruby-versions
 ```
 
 There are many options you can specify with the image build scripts that help with tagging, caching, running builds sequentially vs. parallel, etc. Please view the scripts to see the full options available.
@@ -234,11 +231,8 @@ For building images that support both amd64 and arm64:
 # Build multi-arch Rust containers
 ./scripts/build-rust-images.sh --multiarch
 
-# Build multi-arch language containers (main Ruby versions)
+# Build multi-arch language containers
 ./scripts/build-language-images.sh --multiarch
-
-# Build multi-arch language containers (all Ruby versions)
-./scripts/build-language-images.sh --multiarch --all-ruby-versions
 ```
 
 **Note:** Multi-arch builds use Docker Buildx and may require QEMU for cross-compilation. The build process will be slower than single-architecture builds (2-3x).
@@ -265,9 +259,9 @@ Example published images:
 ghcr.io/nuanced-dev/nuanced-lsp-proxy:0.4.0
 ghcr.io/nuanced-dev/nuanced-lsp-wrapper:0.4.0
 ghcr.io/nuanced-dev/nuanced-lsp-watchdog:0.4.0
-ghcr.io/nuanced-dev/nuanced-lsp-python:0.4.0
-ghcr.io/nuanced-dev/nuanced-lsp-ruby-3.4.4:0.4.0
-ghcr.io/nuanced-dev/nuanced-lsp-ruby-sorbet-3.4.4:0.4.0
+ghcr.io/nuanced-dev/nuanced-lsp-python:1.0.0
+ghcr.io/nuanced-dev/nuanced-lsp-ruby-3.4.4:1.0.0
+ghcr.io/nuanced-dev/nuanced-lsp-ruby-sorbet-3.4.4:1.0.0
 ```
 
 ### Architecture

--- a/clients/typescript/script/test
+++ b/clients/typescript/script/test
@@ -37,6 +37,7 @@ WRAPPER_IMAGE=               # allows overriding the default nuanced-lsp-wrapper
 SYMBOL_SCENARIO_DELAY=       # delay (in seconds) before running symbol scenario tests.
 WORKSPACE_SCENARIO_DELAY=    # delay (in seconds) before running workspace scenario
 NUANCED_LSP_TIMEOUT=         # number of seconds each test case is allowed to run.
+NUANCED_LANGUAGES=           # languages to run tests for
 VITEST_PASSTHRU=()           # additional args to pass to vitest (e.g. specific test files or --testNamePattern).
 
 while [[ $# -gt 0 ]]; do
@@ -109,6 +110,15 @@ while [[ $# -gt 0 ]]; do
         shift 2
       else
         echo "Error: --timeout requires a numeric value (seconds)" >&2
+        exit 2
+      fi
+      ;;
+    --languages)
+      if [[ $# -gt 1 && "$2" != -* ]]; then
+        export NUANCED_LANGUAGES="$2"
+        shift 2
+      else
+        echo "Error: --languages requires a comma-seprated list of languages" >&2
         exit 2
       fi
       ;;

--- a/clients/typescript/src/proxy.ts
+++ b/clients/typescript/src/proxy.ts
@@ -254,7 +254,7 @@ export async function up(
     "-e",
     "USE_AUTH=false",
     "-e",
-    `RUST_LOG=info${debug ? ",nuanced-lsp-proxy=debug,nuanced-lsp-wrapper=debug" : ""}`,
+    `RUST_LOG=info${debug ? ",nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug" : ""}`,
     "-e",
     `WATCHDOG_IMAGE=${watchdogImage}`,
     "-e",

--- a/clients/typescript/tests/helpers/constants.ts
+++ b/clients/typescript/tests/helpers/constants.ts
@@ -13,24 +13,33 @@ const ROOT = path.resolve(__dirname, "..", "..");
 
 export const CLIENT_COMMAND = [path.join(ROOT, "dist/cli.cjs")];
 
-const COMMON_RUBY_VERSIONS = [
+const SUPPORTED_RUBY_VERSIONS = [
   "3.2.2",
   "3.2.6",
   "3.3.5",
   "3.3.6",
+  "3.3.7",
+  "3.3.8",
+  "3.3.9",
+  "3.3.10",
+  "3.4.0",
   "3.4.1",
   "3.4.2",
+  "3.4.3",
   "3.4.4",
+  "3.4.5",
+  "3.4.6",
+  "3.4.7",
 ] as const;
 
 const RUBY_LANGUAGES: LanguageSpec[] = [
   { key: "ruby", label: "Ruby (ruby-lsp + sorbet)" },
-  ...COMMON_RUBY_VERSIONS.map((version) => ({
+  ...SUPPORTED_RUBY_VERSIONS.map((version) => ({
     key: `ruby-${version}`,
     label: `Ruby ${version} (ruby-lsp + sorbet)`,
   })),
   { key: "ruby-no-sorbet", label: "Ruby (ruby-lsp)" },
-  ...COMMON_RUBY_VERSIONS.map((version) => ({
+  ...SUPPORTED_RUBY_VERSIONS.map((version) => ({
     key: `ruby-no-sorbet-${version}`,
     label: `Ruby ${version} (ruby-lsp)`,
   })),

--- a/crates/proxy/src/container/mod.rs
+++ b/crates/proxy/src/container/mod.rs
@@ -489,32 +489,6 @@ impl ContainerOrchestrator {
                         language,
                         info.endpoint
                     );
-
-                    // Spawn health check in background
-                    let orchestrator = self.clone();
-                    let info_clone = info.clone();
-                    tokio::spawn(async move {
-                        match orchestrator.check_container_health(&info_clone).await {
-                            Ok(_) => {
-                                log::info!("{} is now healthy and ready", info_clone.image_name);
-                                orchestrator
-                                    .set_container_health(
-                                        language.clone(),
-                                        ContainerHealthStatus::Healthy,
-                                    )
-                                    .await;
-                            }
-                            Err(e) => {
-                                log::error!("{} health check failed: {}", info_clone.image_name, e);
-                                orchestrator
-                                    .set_container_health(
-                                        language.clone(),
-                                        ContainerHealthStatus::Unhealthy,
-                                    )
-                                    .await;
-                            }
-                        }
-                    });
                 }
                 Err(e) => {
                     log::error!("Failed to spawn container for {:?}: {}", language, e);

--- a/crates/proxy/src/container/orchestrator.rs
+++ b/crates/proxy/src/container/orchestrator.rs
@@ -338,6 +338,23 @@ impl ContainerOrchestrator {
             endpoint
         );
 
+        match self.check_container_health(&info).await {
+            Ok(_) => {
+                log::info!("{} is now healthy and ready", info.image_name);
+                self.set_container_health(language.clone(), ContainerHealthStatus::Healthy)
+                    .await;
+            }
+            Err(e) => {
+                log::error!("{} health check failed: {}", info.image_name, e);
+                self.set_container_health(language.clone(), ContainerHealthStatus::Unhealthy)
+                    .await;
+                return Err(OrchestratorError::HealthCheck(format!(
+                    "{}: {}",
+                    info.image_name, e
+                )));
+            }
+        }
+
         Ok(info)
     }
 

--- a/crates/proxy/tests/container_orchestration_test.rs
+++ b/crates/proxy/tests/container_orchestration_test.rs
@@ -233,7 +233,7 @@ impl ContainerFixture {
         let image_version_env = format!("RUST_IMAGE_VERSION={TEST_RUST_IMAGE_VERSION}");
         let config: Config<&str> = Config {
             image: Some(&proxy_img),
-            env: Some(vec!["USE_AUTH=false", "RUST_LOG=info", &image_version_env]),
+            env: Some(vec!["USE_AUTH=false", "RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug", &image_version_env]),
             host_config: Some(bollard::models::HostConfig {
                 binds: Some(vec![
                     "/var/run/docker.sock:/var/run/docker.sock".to_string(),

--- a/crates/proxy/tests/container_orchestration_test.rs
+++ b/crates/proxy/tests/container_orchestration_test.rs
@@ -377,7 +377,12 @@ async fn test_service_health() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    assert!(response.status().is_success());
+    assert!(
+        response.status().is_success(),
+        "request failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
 
     let health: serde_json::Value = response.json().await?;
     assert_eq!(health["status"], "ok");
@@ -434,7 +439,12 @@ async fn test_container_spawn_on_request() -> Result<(), Box<dyn std::error::Err
         .await?;
 
     // Request should complete successfully
-    assert!(response.status().is_success() || response.status().is_client_error());
+    assert!(
+        response.status().is_success() || response.status().is_client_error(),
+        "failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
 
     // Verify the same container is still being used (no new containers spawned)
     let containers_after_request: Vec<String> = docker
@@ -477,7 +487,12 @@ async fn test_request_forwarding() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    assert!(response.status().is_success());
+    assert!(
+        response.status().is_success(),
+        "request failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
     let body: serde_json::Value = response.json().await?;
 
     // Should have definitions field (even if empty)
@@ -575,7 +590,12 @@ async fn test_list_files() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    assert!(response.status().is_success());
+    assert!(
+        response.status().is_success(),
+        "request failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
     let body: serde_json::Value = response.json().await?;
 
     // The endpoint returns a direct array of filenames, not an object with a "files" field
@@ -605,7 +625,12 @@ async fn test_find_references() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
 
-    assert!(response.status().is_success());
+    assert!(
+        response.status().is_success(),
+        "request failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
     let body: serde_json::Value = response.json().await?;
 
     // Should have references field
@@ -639,7 +664,12 @@ async fn test_find_references_with_context_lines() -> Result<(), Box<dyn std::er
         .send()
         .await?;
 
-    assert!(response.status().is_success());
+    assert!(
+        response.status().is_success(),
+        "request failed: {}: {}",
+        response.status(),
+        response.text().await.unwrap_or_default()
+    );
     let body: serde_json::Value = response.json().await?;
 
     // Verify references field exists

--- a/dockerfiles/proxy.Dockerfile
+++ b/dockerfiles/proxy.Dockerfile
@@ -81,6 +81,8 @@ RUN mkdir -p crates/wrapper/src && \
 # Build nuanced-lsp-proxy binary from workspace with cross-compilation support
 # Uses BuildKit cache mounts to cache Cargo registry and build artifacts across builds.
 # These caches persist even with --no-cache flag, significantly speeding up rebuilds.
+# Note: Each image uses a distinct cache ID (cargo-registry-proxy, cargo-registry-wrapper)
+# to prevent race conditions when building images in parallel.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-proxy \
     --mount=type=cache,target=/usr/src/target,id=cargo-target-proxy \
     mkdir -p /usr/src/bin && \

--- a/dockerfiles/wrapper.Dockerfile
+++ b/dockerfiles/wrapper.Dockerfile
@@ -71,6 +71,8 @@ RUN mkdir -p crates/proxy/src && \
 # Build nuanced-lsp-wrapper binary from workspace
 # Uses BuildKit cache mounts to cache Cargo registry and build artifacts across builds.
 # These caches persist even with --no-cache flag, significantly speeding up rebuilds.
+# Note: Each image uses a distinct cache ID (cargo-registry-proxy, cargo-registry-wrapper)
+# to prevent race conditions when building images in parallel.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-wrapper \
     --mount=type=cache,target=/usr/src/target,id=cargo-target-wrapper \
     mkdir -p /usr/src/bin && \

--- a/scripts/build-language-images.sh
+++ b/scripts/build-language-images.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+
 # Build language server containers (Python, TypeScript, Rust, Go, Java, C++, C#, PHP, Ruby variants)
-# Usage: ./scripts/build-language-images.sh [--use-cache] [--sequential] [--all-ruby-versions] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]
+# Usage: ./scripts/build-language-images.sh [--use-cache] [--sequential] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]
 #
 # By default:
 #   - Builds WITHOUT cache (use --use-cache to enable caching)
@@ -25,7 +27,6 @@ set -e
 #   --sequential          Build sequentially instead of parallel
 #   --parallel            Build in parallel (default)
 #   --jobs=N, -j=N        Max parallel builds (default: 4, prevents Docker daemon overload)
-#   --all-ruby-versions   Build all Ruby versions from dockerfiles (currently 12 versions)
 #   --multiarch           Build for both amd64 and arm64 (default: local platform only)
 #   --load                Also build and load local platform into Docker (use with --multiarch)
 #   --tag=TAG             Tag images with specified semver tag (default: 1.0.0)
@@ -36,7 +37,7 @@ set -e
 # Examples:
 #   ./scripts/build-language-images.sh --tag=1.0.0
 #   ./scripts/build-language-images.sh --multiarch --tag=1.0.0 --registry=ghcr
-#   ./scripts/build-language-images.sh --all-ruby-versions --jobs=8
+#   ./scripts/build-language-images.sh --jobs=8
 #   ./scripts/build-language-images.sh --language=python --multiarch --tag=1.0.0 --registry=ghcr
 #   ./scripts/build-language-images.sh --language=ruby,ruby-sorbet --tag=1.0.0
 #
@@ -53,11 +54,10 @@ BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Default: parallel builds without cache, build main Ruby versions by default, single-arch, no load, v1.0.0 tag
+# Default: parallel builds without cache, single-arch, no load, v1.0.0 tag
 # Language containers use semver where major version = API compatibility version
 PARALLEL=true
 USE_CACHE=false
-ALL_RUBY_VERSIONS=false
 MULTIARCH=false
 LOAD_LOCAL=false
 TAG="1.0.0"
@@ -66,23 +66,21 @@ REGISTRY=""  # Options: ghcr, dockerhub, local, or empty for no push
 FILTER_LANGUAGES=""  # Empty = build all, otherwise comma-separated list: python,typescript,ruby,ruby-sorbet
 # Default max parallel jobs (4 is safe for most systems, prevents Docker daemon overload)
 MAX_JOBS=4
-# Ruby versions to build:
-# - Core versions from original support (3.2.2, 3.2.6, 3.3.5)
-# - Last 1 year of releases (Nov 2024 - Nov 2025): 3.3.6-3.3.10, 3.4.0-3.4.7
-COMMON_RUBY_VERSIONS=("3.2.2" "3.2.6" "3.3.5" "3.3.6" "3.3.7" "3.3.8" "3.3.9" "3.3.10" "3.4.0" "3.4.1" "3.4.2" "3.4.3" "3.4.4" "3.4.5" "3.4.6" "3.4.7")
+
+# Import SUPPORTED_RUBY_VERSIONS
+. "$SCRIPT_DIR/supported-ruby-versions.sh"
 
 # Parse arguments
 for arg in "$@"; do
     case $arg in
         --help|-h)
-            echo "Usage: $0 [--use-cache] [--sequential] [--all-ruby-versions] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]"
+            echo "Usage: $0 [--use-cache] [--sequential] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]"
             echo ""
             echo "Options:"
             echo "  --use-cache           Enable Docker build cache (default: disabled)"
             echo "  --sequential          Build sequentially instead of parallel"
             echo "  --parallel            Build in parallel (default)"
             echo "  --jobs=N, -j=N        Max parallel builds (default: 4, prevents Docker daemon overload)"
-            echo "  --all-ruby-versions   Build all Ruby versions from dockerfiles (currently 12 versions)"
             echo "  --multiarch           Build for both amd64 and arm64 (default: local platform only)"
             echo "  --load                Also build and load local platform into Docker (use with --multiarch)"
             echo "  --tag=TAG             Tag images with specified semver tag (default: 1.0.0)"
@@ -105,7 +103,6 @@ for arg in "$@"; do
             echo "Examples:"
             echo "  $0 --language=python --multiarch --tag=1.0.0 --registry=ghcr"
             echo "  $0 --language=ruby,ruby-sorbet --tag=1.0.0"
-            echo "  $0 --all-ruby-versions --jobs=8"
             exit 0
             ;;
         --sequential)
@@ -116,9 +113,6 @@ for arg in "$@"; do
             ;;
         --parallel)
             PARALLEL=true
-            ;;
-        --all-ruby-versions)
-            ALL_RUBY_VERSIONS=true
             ;;
         --multiarch)
             MULTIARCH=true
@@ -148,14 +142,13 @@ for arg in "$@"; do
             ;;
         *)
             echo -e "${YELLOW}Unknown argument: $arg${NC}"
-            echo "Usage: $0 [--use-cache] [--sequential] [--all-ruby-versions] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]"
+            echo "Usage: $0 [--use-cache] [--sequential] [--multiarch] [--load] [--tag=TAG] [--registry=REGISTRY] [--language=LANG] [--jobs=N]"
             echo ""
             echo "Options:"
             echo "  --use-cache           Enable Docker build cache (default: disabled)"
             echo "  --sequential          Build sequentially instead of parallel"
             echo "  --parallel            Build in parallel (default)"
             echo "  --jobs=N, -j=N        Max parallel builds (default: 4, prevents Docker daemon overload)"
-            echo "  --all-ruby-versions   Build all Ruby versions from dockerfiles (currently 12 versions)"
             echo "  --multiarch           Build for both amd64 and arm64 (default: local platform only)"
             echo "  --load                Also build and load local platform into Docker (use with --multiarch)"
             echo "  --tag=TAG             Tag images with specified semver tag (default: 1.0.0)"
@@ -284,41 +277,15 @@ LANGUAGES=(
 
 # Ruby base images (must be built before Sorbet variants)
 RUBY_VERSIONS=()
-if [ "$ALL_RUBY_VERSIONS" = true ]; then
-    # Build all Ruby versions - dynamically discover from dockerfiles/ruby/ directory
-    echo -e "${YELLOW}Building ALL Ruby versions (this will take a long time)${NC}"
-    if [ -d "dockerfiles/ruby" ]; then
-        for dockerfile in dockerfiles/ruby/*.Dockerfile; do
-            if [ -f "$dockerfile" ]; then
-                # Extract version from filename (e.g., 3.4.4 from 3.4.4.Dockerfile)
-                version=$(basename "$dockerfile" .Dockerfile)
-                RUBY_VERSIONS+=("$version")
-            fi
-        done
-    fi
-else
-    # Build commonly used Ruby versions by default
-    echo -e "${YELLOW}Building main Ruby versions: ${COMMON_RUBY_VERSIONS[*]}${NC}"
-    RUBY_VERSIONS=("${COMMON_RUBY_VERSIONS[@]}")
-fi
+# Build commonly used Ruby versions by default
+echo -e "${YELLOW}Building supported Ruby versions: ${SUPPORTED_RUBY_VERSIONS[*]}${NC}"
+RUBY_VERSIONS=("${SUPPORTED_RUBY_VERSIONS[@]}")
 
 # Ruby Sorbet variants (depend on ruby base images)
 RUBY_SORBET_VERSIONS=()
-if [ "$ALL_RUBY_VERSIONS" = true ]; then
-    # Build all Sorbet versions - same versions as Ruby, from ruby-sorbet directory
-    if [ -d "dockerfiles/ruby-sorbet" ]; then
-        for dockerfile in dockerfiles/ruby-sorbet/*.Dockerfile; do
-            if [ -f "$dockerfile" ]; then
-                # Extract version from filename (e.g., 3.4.4 from 3.4.4.Dockerfile)
-                version=$(basename "$dockerfile" .Dockerfile)
-                RUBY_SORBET_VERSIONS+=("$version")
-            fi
-        done
-    fi
-else
-    # Build commonly used Sorbet versions by default (same as main Ruby versions)
-    RUBY_SORBET_VERSIONS=("${COMMON_RUBY_VERSIONS[@]}")
-fi
+# Build commonly used Sorbet versions by default (same as supported Ruby versions)
+echo -e "${YELLOW}Building supported Sorbet versions: ${SUPPORTED_RUBY_VERSIONS[*]}${NC}"
+RUBY_SORBET_VERSIONS=("${SUPPORTED_RUBY_VERSIONS[@]}")
 
 # Filter languages if --language flag was provided
 if [ -n "$FILTER_LANGUAGES" ]; then

--- a/scripts/publish-images.sh
+++ b/scripts/publish-images.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+
 # Publish Docker images to container registries (ghcr.io and/or Docker Hub)
-# Usage: ./scripts/publish-images.sh <rust-version> [--language-tag=TAG] [--dry-run] [--all-ruby-versions] [--registry=REGISTRY]
+# Usage: ./scripts/publish-images.sh <rust-version> [--language-tag=TAG] [--dry-run] [--registry=REGISTRY]
 #
 # Example: ./scripts/publish-images.sh 0.4.0
 # Example: ./scripts/publish-images.sh 0.4.0 --language-tag=1.0.0
@@ -29,10 +31,11 @@ NC='\033[0m' # No Color
 
 # Default settings
 DRY_RUN=false
-ALL_RUBY_VERSIONS=false
 REGISTRY_TARGET="both"  # Options: ghcr, dockerhub, both
 LANGUAGE_TAG=""  # If not specified, defaults to same as RUST_VERSION
-COMMON_RUBY_VERSIONS=("3.2.2" "3.2.6" "3.3.5" "3.3.6" "3.4.1" "3.4.2" "3.4.4")
+
+# Import SUPPORTED_RUBY_VERSIONS
+. "$SCRIPT_DIR/supported-ruby-versions.sh"
 
 # Parse arguments
 RUST_VERSION=""
@@ -40,9 +43,6 @@ for arg in "$@"; do
     case $arg in
         --dry-run)
             DRY_RUN=true
-            ;;
-        --all-ruby-versions)
-            ALL_RUBY_VERSIONS=true
             ;;
         --language-tag=*)
             LANGUAGE_TAG="${arg#*=}"
@@ -55,7 +55,7 @@ for arg in "$@"; do
             fi
             ;;
         --help|-h)
-            echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--all-ruby-versions] [--registry=REGISTRY]"
+            echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--registry=REGISTRY]"
             echo ""
             echo "Arguments:"
             echo "  <rust-version>        Version tag for Rust containers (e.g., 0.4.0)"
@@ -64,7 +64,6 @@ for arg in "$@"; do
             echo "  --language-tag=TAG    Version tag for language containers (default: same as rust-version)"
             echo "                        Language containers use semver (e.g., 1.0.0) for API compatibility"
             echo "  --dry-run             Show what would be pushed without actually pushing"
-            echo "  --all-ruby-versions   Publish all Ruby versions (default: main versions only)"
             echo "  --registry=REGISTRY   Target registry: ghcr, dockerhub, or both (default: both)"
             echo "  --help, -h            Show this help message"
             echo ""
@@ -79,7 +78,7 @@ for arg in "$@"; do
             ;;
         -*)
             echo -e "${YELLOW}Unknown argument: $arg${NC}"
-            echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--all-ruby-versions] [--registry=REGISTRY]"
+            echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--registry=REGISTRY]"
             exit 1
             ;;
         *)
@@ -87,7 +86,7 @@ for arg in "$@"; do
                 RUST_VERSION="$arg"
             else
                 echo -e "${YELLOW}Unexpected argument: $arg${NC}"
-                echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--all-ruby-versions] [--registry=REGISTRY]"
+                echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--registry=REGISTRY]"
                 exit 1
             fi
             ;;
@@ -97,7 +96,7 @@ done
 # Validate rust version argument
 if [ -z "$RUST_VERSION" ]; then
     echo -e "${RED}Error: Rust version argument is required${NC}"
-    echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--all-ruby-versions] [--registry=REGISTRY]"
+    echo "Usage: $0 <rust-version> [--language-tag=TAG] [--dry-run] [--registry=REGISTRY]"
     exit 1
 fi
 
@@ -291,20 +290,8 @@ echo
 
 # Determine Ruby versions to publish (use LANGUAGE_TAG)
 RUBY_VERSIONS=()
-if [ "$ALL_RUBY_VERSIONS" = true ]; then
-    echo -e "${YELLOW}Step 3: Publishing ALL Ruby versions (version: $LANGUAGE_TAG)${NC}"
-    if [ -d "dockerfiles/ruby" ]; then
-        for dockerfile in dockerfiles/ruby/*.Dockerfile; do
-            if [ -f "$dockerfile" ]; then
-                version=$(basename "$dockerfile" .Dockerfile)
-                RUBY_VERSIONS+=("$version")
-            fi
-        done
-    fi
-else
-    echo -e "${YELLOW}Step 3: Publishing main Ruby versions (version: $LANGUAGE_TAG)${NC}"
-    RUBY_VERSIONS=("${COMMON_RUBY_VERSIONS[@]}")
-fi
+echo -e "${YELLOW}Step 3: Publishing supported Ruby versions (version: $LANGUAGE_TAG)${NC}"
+RUBY_VERSIONS=("${SUPPORTED_RUBY_VERSIONS[@]}")
 echo
 
 failed=0
@@ -321,20 +308,8 @@ echo
 
 # Ruby Sorbet variants (use LANGUAGE_TAG)
 RUBY_SORBET_VERSIONS=()
-if [ "$ALL_RUBY_VERSIONS" = true ]; then
-    echo -e "${YELLOW}Step 4: Publishing ALL Ruby Sorbet versions (version: $LANGUAGE_TAG)${NC}"
-    if [ -d "dockerfiles/ruby-sorbet" ]; then
-        for dockerfile in dockerfiles/ruby-sorbet/*.Dockerfile; do
-            if [ -f "$dockerfile" ]; then
-                version=$(basename "$dockerfile" .Dockerfile)
-                RUBY_SORBET_VERSIONS+=("$version")
-            fi
-        done
-    fi
-else
-    echo -e "${YELLOW}Step 4: Publishing main Ruby Sorbet versions (version: $LANGUAGE_TAG)${NC}"
-    RUBY_SORBET_VERSIONS=("${COMMON_RUBY_VERSIONS[@]}")
-fi
+echo -e "${YELLOW}Step 4: Publishing supported Ruby Sorbet versions (version: $LANGUAGE_TAG)${NC}"
+RUBY_SORBET_VERSIONS=("${SUPPORTED_RUBY_VERSIONS[@]}")
 echo
 
 failed=0

--- a/scripts/start-proxy.sh
+++ b/scripts/start-proxy.sh
@@ -115,7 +115,7 @@ DOCKER_RUN_CMD="$DOCKER_RUN_CMD \
     -p ${PORT}:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v \"${WORKSPACE_PATH}:/mnt/workspace\" \
-    -e RUST_LOG=info \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \
     -e NUANCED_LSP_MAX_MEMORY=8192"

--- a/scripts/supported-ruby-versions.sh
+++ b/scripts/supported-ruby-versions.sh
@@ -1,0 +1,4 @@
+# Supported Ruby versions:
+# - Core versions from original support (3.2.2, 3.2.6, 3.3.5)
+# - Last 1 year of releases (Nov 2024 - Nov 2025): 3.3.6-3.3.10, 3.4.0-3.4.7
+export SUPPORTED_RUBY_VERSIONS=("3.2.2" "3.2.6" "3.3.5" "3.3.6" "3.3.7" "3.3.8" "3.3.9" "3.3.10" "3.4.0" "3.4.1" "3.4.2" "3.4.3" "3.4.4" "3.4.5" "3.4.6" "3.4.7")

--- a/scripts/test-container-lifecycle.sh
+++ b/scripts/test-container-lifecycle.sh
@@ -90,7 +90,7 @@ docker run -d \
     -p 4444:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$WORKSPACE_PATH:/mnt/workspace" \
-    -e RUST_LOG=info \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e USE_AUTH=false \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \

--- a/scripts/test-watchdog.sh
+++ b/scripts/test-watchdog.sh
@@ -192,7 +192,7 @@ docker run -d \
     -p 4455:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$WORKSPACE_PATH:/mnt/workspace" \
-    -e RUST_LOG=info \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e USE_AUTH=false \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \
@@ -262,7 +262,7 @@ docker run -d \
     -p 4456:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$WORKSPACE_PATH:/mnt/workspace" \
-    -e RUST_LOG=info \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e USE_AUTH=false \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \
@@ -313,7 +313,7 @@ docker run -d \
     -p 4457:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$WORKSPACE_PATH:/mnt/workspace" \
-    -e RUST_LOG=warn \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e USE_AUTH=false \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \
@@ -324,7 +324,7 @@ docker run -d \
     -p 4458:4444 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v "$WORKSPACE_PATH:/mnt/workspace" \
-    -e RUST_LOG=warn \
+    -e RUST_LOG=info,nuanced_lsp_proxy=debug,proxy=debug,nuanced_lsp_wrapper=debug,wrapper=debug \
     -e USE_AUTH=false \
     -e WRAPPER_IMAGE=nuanced-lsp-wrapper:${RUST_VERSION} \
     -e WATCHDOG_IMAGE=nuanced-lsp-watchdog:${RUST_VERSION} \


### PR DESCRIPTION
| |
|-|
| #19 ➡️ |

Docker image versions are hard coded in several places. This PR changes that to default to the Rust crate version. This ensures that selecting a specific proxy image version, it will automatically use the corresponding wrapper & watchdog image versions, instead of the hard-coded defaults.

## Tasks

- [ ] Remove hard-coded versions in favor of crate version
- [ ] Simplify setup by always using versioned images instead of `latest`
- [ ] Review and cleanup build, test, and release scripts for the new setup
- [ ] Release
